### PR TITLE
Adaptations for SGE Job Scheduler

### DIFF
--- a/isotherm/isotherm.ipynb
+++ b/isotherm/isotherm.ipynb
@@ -304,6 +304,7 @@
     "            \"num_machines\": 1,\n",
     "            \"tot_num_mpiprocs\": 1,\n",
     "            \"num_mpiprocs_per_machine\": 1,\n",
+    "            \"parallel_env\": \"mpi\",\n",
     "        },\n",
     "        \"max_wallclock_seconds\": 5 * 60 * 60,\n",
     "        \"withmpi\": False,\n",

--- a/workflows/isotherm/__init__.py
+++ b/workflows/isotherm/__init__.py
@@ -54,7 +54,8 @@ class Isotherm(WorkChain):
             "resources": {
                 "num_machines": 1,
                 "tot_num_mpiprocs": 1,
-                "num_mpiprocs_per_machine": 1,
+                "num_mpiprocs_per_machine": 1, 
+                "parallel_env": 'mpi',
             },
             "max_wallclock_seconds": 30 * 60,
             "withmpi": False,
@@ -137,6 +138,7 @@ class Isotherm(WorkChain):
             "resources": {
                 "num_machines": 4,
                 "num_mpiprocs_per_machine": 12,
+                "parallel_env": 'mpi',
             },
             "max_wallclock_seconds": 3 * 60 * 60,
         }


### PR DESCRIPTION
On Pitzer the jobs were failing with the error message "parallel_env"
not set, which has now been rectified.